### PR TITLE
EN-180: Add Efficiency numbers and cmd / est height to QGroundControl…

### DIFF
--- a/src/Vehicle/EscStatusFactGroup.json
+++ b/src/Vehicle/EscStatusFactGroup.json
@@ -4,103 +4,46 @@
     "QGC.MetaData.Facts":
 [
 {
-    "name":             "index",
-    "shortDesc":        "Index Of The First ESC In This Message",
-    "type":             "uint8",
-    "default":          0
-},
-{
-    "name":             "rpmFirst",
-    "shortDesc":        "Rotation Per Minute",
+    "name":             "rpm",
+    "shortDesc":        "RPM",
     "type":             "float",
-    "decimalPlaces":    2,
+    "decimalPlaces":    0,
     "default":          null
 },
 {
-    "name":             "rpmSecond",
-    "shortDesc":        "Rotation Per Minute",
+    "name":             "mechPwr",
+    "shortDesc":        "Mech Power",
     "type":             "float",
-    "decimalPlaces":    2,
+    "decimalPlaces":    0,
     "default":          null
 },
 {
-    "name":             "rpmThird",
-    "shortDesc":        "Rotation Per Minute",
+    "name":             "efficiency",
+    "shortDesc":        "Efficiency (%)",
     "type":             "float",
-    "decimalPlaces":    2,
+    "decimalPlaces":    1,
     "default":          null
 },
 {
-    "name":             "rpmFourth",
-    "shortDesc":        "Rotation Per Minute",
+    "name":             "gPerW",
+    "shortDesc":        "Grams per Watt",
     "type":             "float",
-    "decimalPlaces":    2,
+    "decimalPlaces":    0,
     "default":          null
 },
 {
-    "name":             "currentFirst",
-    "shortDesc":        "Current",
+    "name":             "cmdHeight",
+    "shortDesc":        "Cmd Height (m)",
     "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "A"
-
+    "decimalPlaces":    0,
+    "default":          null
 },
 {
-    "name":             "currentSecond",
-    "shortDesc":        "Current",
+    "name":             "estHeight",
+    "shortDesc":        "Est Height (m)",
     "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "A"
-},
-{
-    "name":             "currentThird",
-    "shortDesc":        "Current",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "A"
-},
-{
-    "name":             "currentFourth",
-    "shortDesc":        "Current",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "A"
-},
-{
-    "name":             "voltageFirst",
-    "shortDesc":        "Voltage",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "v"
-},
-{
-    "name":             "voltageSecond",
-    "shortDesc":        "Voltage",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "v"
-},
-{
-    "name":             "voltageThird",
-    "shortDesc":        "Voltage",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "v"
-},
-{
-    "name":             "voltageFourth",
-    "shortDesc":        "Voltage",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "v"
+    "decimalPlaces":    0,
+    "default":          null
 }
 ]
 }

--- a/src/Vehicle/EscStatusFactGroup.json
+++ b/src/Vehicle/EscStatusFactGroup.json
@@ -44,6 +44,13 @@
     "type":             "float",
     "decimalPlaces":    0,
     "default":          null
+},
+{
+    "name":             "elevatorAngle",
+    "shortDesc":        "Elevator Angle (deg)",
+    "type":             "float",
+    "decimalPlaces":    1,
+    "default":          null
 }
 ]
 }

--- a/src/Vehicle/VehicleEscStatusFactGroup.cc
+++ b/src/Vehicle/VehicleEscStatusFactGroup.cc
@@ -16,6 +16,7 @@ const char* VehicleEscStatusFactGroup::_efficiencyFactName =                    
 const char* VehicleEscStatusFactGroup::_gPerWFactName =                             "gPerW";
 const char* VehicleEscStatusFactGroup::_cmdHeightFactName =                         "cmdHeight";
 const char* VehicleEscStatusFactGroup::_estHeightFactName =                         "estHeight";
+const char* VehicleEscStatusFactGroup::_elevatorAngleFactName =                     "elevatorAngle";
 
 
 VehicleEscStatusFactGroup::VehicleEscStatusFactGroup(QObject* parent)
@@ -26,6 +27,7 @@ VehicleEscStatusFactGroup::VehicleEscStatusFactGroup(QObject* parent)
     , _gPerWFact                        (0, _gPerWFactName,                         FactMetaData::valueTypeFloat)
     , _cmdHeightFact                    (0, _cmdHeightFactName,                     FactMetaData::valueTypeFloat)
     , _estHeightFact                    (0, _estHeightFactName,                     FactMetaData::valueTypeFloat)
+    , _elevatorAngleFact                (0, _elevatorAngleFactName,                 FactMetaData::valueTypeFloat)
 
 {
     _addFact(&_rpmFact,                         _rpmFactName);
@@ -34,6 +36,7 @@ VehicleEscStatusFactGroup::VehicleEscStatusFactGroup(QObject* parent)
     _addFact(&_gPerWFact,                       _gPerWFactName);
     _addFact(&_cmdHeightFact,                   _cmdHeightFactName);
     _addFact(&_estHeightFact,                   _estHeightFactName);
+    _addFact(&_elevatorAngleFact,               _elevatorAngleFactName);
 }
 
 void VehicleEscStatusFactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_message_t& message)
@@ -53,7 +56,8 @@ void VehicleEscStatusFactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_me
     } else if (message.msgid == MAVLINK_MSG_ID_DEBUG_FLOAT_ARRAY) {
         mavlink_debug_float_array_t content;
         mavlink_msg_debug_float_array_decode(&message, &content);
-        cmdHeight()->setRawValue                    (content.data[33]);
-        estHeight()->setRawValue                    (content.data[34]);
+        cmdHeight()->setRawValue                    (content.data[50]);
+        estHeight()->setRawValue                    (content.data[51]);
+        elevatorAngle()->setRawValue                (content.data[36]*180/3.14159);
     }
 }

--- a/src/Vehicle/VehicleEscStatusFactGroup.cc
+++ b/src/Vehicle/VehicleEscStatusFactGroup.cc
@@ -10,83 +10,50 @@
 #include "VehicleEscStatusFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleEscStatusFactGroup::_indexFactName =                             "index";
+const char* VehicleEscStatusFactGroup::_rpmFactName =                               "rpm";
+const char* VehicleEscStatusFactGroup::_mechPwrFactName =                           "mechPwr";
+const char* VehicleEscStatusFactGroup::_efficiencyFactName =                        "efficiency";
+const char* VehicleEscStatusFactGroup::_gPerWFactName =                             "gPerW";
+const char* VehicleEscStatusFactGroup::_cmdHeightFactName =                         "cmdHeight";
+const char* VehicleEscStatusFactGroup::_estHeightFactName =                         "estHeight";
 
-const char* VehicleEscStatusFactGroup::_rpmFirstFactName =                          "rpm1";
-const char* VehicleEscStatusFactGroup::_rpmSecondFactName =                         "rpm2";
-const char* VehicleEscStatusFactGroup::_rpmThirdFactName =                          "rpm3";
-const char* VehicleEscStatusFactGroup::_rpmFourthFactName =                         "rpm4";
-
-const char* VehicleEscStatusFactGroup::_currentFirstFactName =                      "current1";
-const char* VehicleEscStatusFactGroup::_currentSecondFactName =                     "current2";
-const char* VehicleEscStatusFactGroup::_currentThirdFactName =                      "current3";
-const char* VehicleEscStatusFactGroup::_currentFourthFactName =                     "current4";
-
-const char* VehicleEscStatusFactGroup::_voltageFirstFactName =                      "voltage1";
-const char* VehicleEscStatusFactGroup::_voltageSecondFactName =                     "voltage2";
-const char* VehicleEscStatusFactGroup::_voltageThirdFactName =                      "voltage3";
-const char* VehicleEscStatusFactGroup::_voltageFourthFactName =                     "voltage4";
 
 VehicleEscStatusFactGroup::VehicleEscStatusFactGroup(QObject* parent)
     : FactGroup                         (1000, ":/json/Vehicle/EscStatusFactGroup.json", parent)
-    , _indexFact                        (0, _indexFactName,                         FactMetaData::valueTypeUint8)
+    , _rpmFact                          (0, _rpmFactName,                           FactMetaData::valueTypeFloat)
+    , _mechPwrFact                      (0, _mechPwrFactName,                       FactMetaData::valueTypeFloat)
+    , _efficiencyFact                   (0, _efficiencyFactName,                    FactMetaData::valueTypeFloat)
+    , _gPerWFact                        (0, _gPerWFactName,                         FactMetaData::valueTypeFloat)
+    , _cmdHeightFact                    (0, _cmdHeightFactName,                     FactMetaData::valueTypeFloat)
+    , _estHeightFact                    (0, _estHeightFactName,                     FactMetaData::valueTypeFloat)
 
-    , _rpmFirstFact                     (0, _rpmFirstFactName,                      FactMetaData::valueTypeFloat)
-    , _rpmSecondFact                    (0, _rpmSecondFactName,                     FactMetaData::valueTypeFloat)
-    , _rpmThirdFact                     (0, _rpmThirdFactName,                      FactMetaData::valueTypeFloat)
-    , _rpmFourthFact                    (0, _rpmFourthFactName,                     FactMetaData::valueTypeFloat)
-
-    , _currentFirstFact                 (0, _currentFirstFactName,                  FactMetaData::valueTypeFloat)
-    , _currentSecondFact                (0, _currentSecondFactName,                 FactMetaData::valueTypeFloat)
-    , _currentThirdFact                 (0, _currentThirdFactName,                  FactMetaData::valueTypeFloat)
-    , _currentFourthFact                (0, _currentFourthFactName,                 FactMetaData::valueTypeFloat)
-
-    , _voltageFirstFact                 (0, _voltageFirstFactName,                  FactMetaData::valueTypeFloat)
-    , _voltageSecondFact                (0, _voltageSecondFactName,                 FactMetaData::valueTypeFloat)
-    , _voltageThirdFact                 (0, _voltageThirdFactName,                  FactMetaData::valueTypeFloat)
-    , _voltageFourthFact                (0, _voltageFourthFactName,                 FactMetaData::valueTypeFloat)
 {
-    _addFact(&_indexFact,                       _indexFactName);
-
-    _addFact(&_rpmFirstFact,                    _rpmFirstFactName);
-    _addFact(&_rpmSecondFact,                   _rpmSecondFactName);
-    _addFact(&_rpmThirdFact,                    _rpmThirdFactName);
-    _addFact(&_rpmFourthFact,                   _rpmFourthFactName);
-
-    _addFact(&_currentFirstFact,                _currentFirstFactName);
-    _addFact(&_currentSecondFact,               _currentSecondFactName);
-    _addFact(&_currentThirdFact,                _currentThirdFactName);
-    _addFact(&_currentFourthFact,               _currentFourthFactName);
-
-    _addFact(&_voltageFirstFact,                _voltageFirstFactName);
-    _addFact(&_voltageSecondFact,               _voltageSecondFactName);
-    _addFact(&_voltageThirdFact,                _voltageThirdFactName);
-    _addFact(&_voltageFourthFact,               _voltageFourthFactName);
+    _addFact(&_rpmFact,                         _rpmFactName);
+    _addFact(&_mechPwrFact,                     _mechPwrFactName);
+    _addFact(&_efficiencyFact,                  _efficiencyFactName);
+    _addFact(&_gPerWFact,                       _gPerWFactName);
+    _addFact(&_cmdHeightFact,                   _cmdHeightFactName);
+    _addFact(&_estHeightFact,                   _estHeightFactName);
 }
 
 void VehicleEscStatusFactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_message_t& message)
 {
-    if (message.msgid != MAVLINK_MSG_ID_ESC_STATUS) {
-        return;
+    if (message.msgid == MAVLINK_MSG_ID_DEBUG_VECT) {
+        mavlink_debug_vect_t content;
+        mavlink_msg_debug_vect_decode(&message, &content);
+
+        mechPwr()->setRawValue                      (content.x);
+        efficiency()->setRawValue                   (content.y);
+        gPerW()->setRawValue                        (content.z);
+    } else if (message.msgid == MAVLINK_MSG_ID_RAW_RPM) {
+        mavlink_raw_rpm_t content;
+        mavlink_msg_raw_rpm_decode(&message, &content);
+
+        rpm()->setRawValue                          (content.frequency);
+    } else if (message.msgid == MAVLINK_MSG_ID_DEBUG_FLOAT_ARRAY) {
+        mavlink_debug_float_array_t content;
+        mavlink_msg_debug_float_array_decode(&message, &content);
+        cmdHeight()->setRawValue                    (content.data[33]);
+        estHeight()->setRawValue                    (content.data[34]);
     }
-
-    mavlink_esc_status_t content;
-    mavlink_msg_esc_status_decode(&message, &content);
-
-    index()->setRawValue                        (content.index);
-
-    rpmFirst()->setRawValue                     (content.rpm[0]);
-    rpmSecond()->setRawValue                    (content.rpm[1]);
-    rpmThird()->setRawValue                     (content.rpm[2]);
-    rpmFourth()->setRawValue                    (content.rpm[3]);
-
-    currentFirst()->setRawValue                 (content.current[0]);
-    currentSecond()->setRawValue                (content.current[1]);
-    currentThird()->setRawValue                 (content.current[2]);
-    currentFourth()->setRawValue                (content.current[3]);
-
-    voltageFirst()->setRawValue                 (content.voltage[0]);
-    voltageSecond()->setRawValue                (content.voltage[1]);
-    voltageThird()->setRawValue                 (content.voltage[2]);
-    voltageFourth()->setRawValue                (content.voltage[3]);
 }

--- a/src/Vehicle/VehicleEscStatusFactGroup.h
+++ b/src/Vehicle/VehicleEscStatusFactGroup.h
@@ -21,74 +21,35 @@ class VehicleEscStatusFactGroup : public FactGroup
 public:
     VehicleEscStatusFactGroup(QObject* parent = nullptr);
 
-    Q_PROPERTY(Fact* index              READ index              CONSTANT)
+    Q_PROPERTY(Fact* rpm                READ rpm                CONSTANT)
+    Q_PROPERTY(Fact* mechPwr            READ mechPwr            CONSTANT)
+    Q_PROPERTY(Fact* efficiency         READ efficiency         CONSTANT)
+    Q_PROPERTY(Fact* gPerW              READ gPerW              CONSTANT)
+    Q_PROPERTY(Fact* cmdHeight          READ cmdHeight          CONSTANT)
+    Q_PROPERTY(Fact* estHeight          READ estHeight          CONSTANT)
 
-    Q_PROPERTY(Fact* rpmFirst           READ rpmFirst           CONSTANT)
-    Q_PROPERTY(Fact* rpmSecond          READ rpmSecond          CONSTANT)
-    Q_PROPERTY(Fact* rpmThird           READ rpmThird           CONSTANT)
-    Q_PROPERTY(Fact* rpmFourth          READ rpmFourth          CONSTANT)
-
-    Q_PROPERTY(Fact* currentFirst       READ currentFirst       CONSTANT)
-    Q_PROPERTY(Fact* currentSecond      READ currentSecond      CONSTANT)
-    Q_PROPERTY(Fact* currentThird       READ currentThird       CONSTANT)
-    Q_PROPERTY(Fact* currentFourth      READ currentFourth      CONSTANT)
-
-    Q_PROPERTY(Fact* voltageFirst       READ voltageFirst       CONSTANT)
-    Q_PROPERTY(Fact* voltageSecond      READ voltageSecond      CONSTANT)
-    Q_PROPERTY(Fact* voltageThird       READ voltageThird       CONSTANT)
-    Q_PROPERTY(Fact* voltageFourth      READ voltageFourth      CONSTANT)
-
-    Fact* index                         () { return &_indexFact; }
-
-    Fact* rpmFirst                      () { return &_rpmFirstFact; }
-    Fact* rpmSecond                     () { return &_rpmSecondFact; }
-    Fact* rpmThird                      () { return &_rpmThirdFact; }
-    Fact* rpmFourth                     () { return &_rpmFourthFact; }
-
-    Fact* currentFirst                  () { return &_currentFirstFact; }
-    Fact* currentSecond                 () { return &_currentSecondFact; }
-    Fact* currentThird                  () { return &_currentThirdFact; }
-    Fact* currentFourth                 () { return &_currentFourthFact; }
-
-    Fact* voltageFirst                  () { return &_voltageFirstFact; }
-    Fact* voltageSecond                 () { return &_voltageSecondFact; }
-    Fact* voltageThird                  () { return &_voltageThirdFact; }
-    Fact* voltageFourth                 () { return &_voltageFourthFact; }
+    Fact* rpm                           () { return &_rpmFact; }
+    Fact* mechPwr                       () { return &_mechPwrFact; }
+    Fact* efficiency                    () { return &_efficiencyFact; }
+    Fact* gPerW                         () { return &_gPerWFact; }
+    Fact* cmdHeight                     () { return &_cmdHeightFact; }
+    Fact* estHeight                     () { return &_estHeightFact; }
 
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _indexFactName;
+    static const char* _rpmFactName;
+    static const char* _mechPwrFactName;
+    static const char* _efficiencyFactName;
+    static const char* _gPerWFactName;
+    static const char* _cmdHeightFactName;
+    static const char* _estHeightFactName;
 
-    static const char* _rpmFirstFactName;
-    static const char* _rpmSecondFactName;
-    static const char* _rpmThirdFactName;
-    static const char* _rpmFourthFactName;
-
-    static const char* _currentFirstFactName;
-    static const char* _currentSecondFactName;
-    static const char* _currentThirdFactName;
-    static const char* _currentFourthFactName;
-
-    static const char* _voltageFirstFactName;
-    static const char* _voltageSecondFactName;
-    static const char* _voltageThirdFactName;
-    static const char* _voltageFourthFactName;
 private:
-    Fact _indexFact;
-
-    Fact _rpmFirstFact;
-    Fact _rpmSecondFact;
-    Fact _rpmThirdFact;
-    Fact _rpmFourthFact;
-
-    Fact _currentFirstFact;
-    Fact _currentSecondFact;
-    Fact _currentThirdFact;
-    Fact _currentFourthFact;
-
-    Fact _voltageFirstFact;
-    Fact _voltageSecondFact;
-    Fact _voltageThirdFact;
-    Fact _voltageFourthFact;
+    Fact _rpmFact;
+    Fact _mechPwrFact;
+    Fact _efficiencyFact;
+    Fact _gPerWFact;
+    Fact _cmdHeightFact;
+    Fact _estHeightFact;
 };

--- a/src/Vehicle/VehicleEscStatusFactGroup.h
+++ b/src/Vehicle/VehicleEscStatusFactGroup.h
@@ -27,6 +27,7 @@ public:
     Q_PROPERTY(Fact* gPerW              READ gPerW              CONSTANT)
     Q_PROPERTY(Fact* cmdHeight          READ cmdHeight          CONSTANT)
     Q_PROPERTY(Fact* estHeight          READ estHeight          CONSTANT)
+    Q_PROPERTY(Fact* elevatorAngle      READ elevatorAngle      CONSTANT)
 
     Fact* rpm                           () { return &_rpmFact; }
     Fact* mechPwr                       () { return &_mechPwrFact; }
@@ -34,6 +35,7 @@ public:
     Fact* gPerW                         () { return &_gPerWFact; }
     Fact* cmdHeight                     () { return &_cmdHeightFact; }
     Fact* estHeight                     () { return &_estHeightFact; }
+    Fact* elevatorAngle                 () { return &_elevatorAngleFact; }
 
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
@@ -44,6 +46,7 @@ public:
     static const char* _gPerWFactName;
     static const char* _cmdHeightFactName;
     static const char* _estHeightFactName;
+    static const char* _elevatorAngleFactName;
 
 private:
     Fact _rpmFact;
@@ -52,4 +55,5 @@ private:
     Fact _gPerWFact;
     Fact _cmdHeightFact;
     Fact _estHeightFact;
+    Fact _elevatorAngleFact;
 };


### PR DESCRIPTION
EN-180: Add Efficiency numbers and cmd / est height to QGroundControl so we can see them live.  Use the ESC control structure to make it easier


